### PR TITLE
Added timeout implementation

### DIFF
--- a/lib/exdisque.ex
+++ b/lib/exdisque.ex
@@ -11,8 +11,20 @@ defmodule ExDisque do
 
   Returns the `pid` of the connected client.
   """
-  def start_link(host \\ "127.0.0.1", port \\ 7711, database \\ 0, password \\ "", reconnect \\ :no_reconnect) do
-    :eredis.start_link(String.to_char_list(host), port, database, String.to_char_list(password), reconnect)
+  def start_link(
+        host \\ "127.0.0.1",
+        port \\ 7711,
+        database \\ 0,
+        password \\ "",
+        reconnect \\ :no_reconnect
+      ) do
+    :eredis.start_link(
+      String.to_charlist(host),
+      port,
+      database,
+      String.to_charlist(password),
+      reconnect
+    )
   end
 
   @doc """
@@ -29,12 +41,24 @@ defmodule ExDisque do
   @doc """
   Execute a query on the `client` with the given arguments.
 
-  * `query client, ["ADDJOB", "queue_name", "job_body", "0"]`
-  * `query client, ["GETJOB", "FROM", "queue_name"]`
+  * `query(client, ["ADDJOB", "queue_name", "job_body", "0"])`
+  * `query(client, ["GETJOB", "FROM", "queue_name"])`
 
   See more Disque command examples on the [Disque repo](https://github.com/antirez/disque#api).
   """
   def query(pid, command) when is_pid(pid) and is_list(command) do
-    :eredis.q(pid, command) |> elem 1
+    :eredis.q(pid, command) |> elem(1)
+  end
+
+  @doc """
+  Same as above, but provide a timeout. This is particularly useful when
+  creating a consumer that blocks until a job is received.
+
+  `query(client, ["GETJOB", "FROM", "queue_name"], :infinity)`
+  ```
+  """
+  def query(pid, command, timeout)
+      when is_pid(pid) and is_list(command) and (is_integer(timeout) or timeout == :infinity) do
+    :eredis.q(pid, command, timeout) |> elem(1)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,15 +2,17 @@ defmodule ExDisque.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :exdisque,
-     version: "0.0.1",
-     elixir: "~> 1.0",
-     name: "exdisque",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps,
-     package: package,
-     description: "Elixir client library for Disque: https://github.com/antirez/disque"]
+    [
+      app: :exdisque,
+      version: "0.0.1",
+      elixir: "~> 1.0",
+      name: "exdisque",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      package: package(),
+      description: "Elixir client library for Disque: https://github.com/antirez/disque"
+    ]
   end
 
   def application do
@@ -22,8 +24,10 @@ defmodule ExDisque.Mixfile do
   end
 
   defp package do
-    [contributors: ["Miloš Mošić"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/mosic/exdisque"}]
+    [
+      contributors: ["Miloš Mošić"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/mosic/exdisque"}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,3 @@
-%{"eredis": {:hex, :eredis, "1.0.7"}}
+%{
+  "eredis": {:hex, :eredis, "1.0.7", "9b018acf002b9ba5bbd570483bd1076f869e054822f1ecefda2fee25f6c27e38", [:make, :rebar], [], "hexpm"},
+}


### PR DESCRIPTION
In the current implementation of `exdisque` it is not possible to execute a `GET_JOB` query longer than five seconds that blocks until a job is received due to `eredis`'s default timeout of `5000`.

This pull request adds the ability to optionally provide a timeout, including a timeout of `:infinity` which will allow consumers to block until a job is received.

As a plus I also ran the Elixir formatter and changed `to_char_list` to `to_charlist`.